### PR TITLE
Fix: Ensure teacher names adapt to dark mode

### DIFF
--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -34,6 +34,6 @@
 .colabName h3 {
   font-size: 1.25rem; /* Adjusted font size */
   margin-top: 1rem; /* Added margin for spacing */
-  color: #333; /* Darker color for better readability */
+  color: var(--ifm-font-color-base); /* Use Docusaurus CSS variable for theme-adaptive color */
 }
 


### PR DESCRIPTION
Updated the text color for teacher names to use a Docusaurus CSS variable, ensuring compatibility with both light and dark themes.