### PR TITLE
feat: Deploy PR previews to separate gh-pages branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,11 +4,15 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
 permissions:
   contents: write
+  pull-requests: write # Required for adding comments to PRs
 
 jobs:
   deploy:
@@ -17,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # Not strictly necessary for this workflow, but good practice
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -28,23 +32,56 @@ jobs:
       - name: Build website
         run: npm run build
 
-      # Popular action to deploy to GitHub Pages:
-      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
-      - name: Deploy to GitHub Pages
+      - name: Deploy to GitHub Pages (Production)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Build output to publish to the `gh-pages` branch:
           publish_dir: ./build
-          # The following lines assign commit authorship to the official
-          # GH-Actions bot for deploys to `gh-pages` branch:
-          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
-          # The GH actions bot is used by default if you didn't specify the two fields.
-          # You can swap them out with your own user credentials.
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com
-      - name: Notify Slack
-        if: success() && !endsWith(github.event.head_commit.message, '-silent')
+
+      - name: Deploy to GitHub Pages (Preview)
+        if: github.event_name == 'pull_request'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+          publish_branch: gh-pages-preview/${{ github.head_ref }} # Deploy to a branch like gh-pages-preview/my-feature-branch
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          # Optional: Add a comment to the PR with the preview link
+          # cname: preview.example.com # If you have a custom domain for previews
+
+      - name: Add PR Comment with Preview Link
+        if: github.event_name == 'pull_request' && success()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const repoOwner = context.repo.owner;
+            const repoName = context.repo.repo;
+            const prBranch = "${{ github.head_ref }}";
+            // Construct the GitHub Pages URL. This assumes standard GitHub Pages path structure.
+            // It might need adjustment if your repo name has dots or specific casing.
+            // Or if you use a custom domain for the main gh-pages.
+            // For user/organization pages (repo name is owner.github.io), the path is just /branchname
+            // For project pages, the path is /repo-name/branchname
+            let previewUrl;
+            if (repoName.toLowerCase() === `${repoOwner.toLowerCase()}.github.io`) {
+              previewUrl = `https://${repoOwner}.github.io/gh-pages-preview/${prBranch}`;
+            } else {
+              previewUrl = `https://${repoOwner}.github.io/${repoName}/gh-pages-preview/${prBranch}`;
+            }
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🚀 Preview deployment for this PR is available at: [${previewUrl}](${previewUrl})\n\n**Important:** You might need to enable GitHub Pages for the \`gh-pages-preview/${prBranch}\` branch in your repository settings if this is the first deployment for this branch.`
+            });
+
+      - name: Notify Slack (Production Deployment)
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main' && !endsWith(github.event.head_commit.message, '-silent')
         run: |
           curl -d "text=🚀 Nuevo cambio en la pagina!! <https://github.com/${{ github.repository }}/commit/${{ github.sha }}| ${{ github.event.head_commit.message }}>" \
                -d "channel=${{ secrets.SLACK_CHANNEL }}" \


### PR DESCRIPTION
This commit updates the GitHub Actions workflow to:
- Deploy to the standard `gh-pages` branch on pushes to `main` (production).
- Deploy to a new branch `gh-pages-preview/<pr-branch-name>` on pull requests targeting `main` (previews).
- Add a comment to the pull request with a link to the preview deployment and instructions for enabling GitHub Pages for the preview branch if necessary.
- Ensure Slack notifications are only sent for production deployments.