### PR TITLE
Contenido: agregar enunciado del Trabajo Práctico 2026

### DIFF
--- a/src/pages/trabajos-practicos.md
+++ b/src/pages/trabajos-practicos.md
@@ -1,7 +1,96 @@
-# Trabajos Prácticos
+# Trabajo Práctico - Introducción al Desarrollo de Software
 
-:::info El trabajo práctico se está redactando...
+## Objetivo
 
-El enunciado estará listo más cerca de la fecha de presentación :)
+Los alumnos deben demostrar la comprensión de los conceptos aprendidos en clase y la habilidad para aplicarlos en la resolución de problemas, junto con el desarrollo de una idea creativa y propia.
+
+## Descripción
+
+Los alumnos deberán desarrollar un sitio web completo utilizando las tecnologías vistas a lo largo de la materia. El mismo constará de un frontend y un backend, con persistencia de datos utilizando una base de datos. El sitio web deberá tener una temática creativa y original, elegida por cada grupo, y deberá cumplir con los siguientes requisitos:
+
+- El backend deberá ser una API REST.
+- El frontend deberá ser un sitio estático, con al menos tres (3) páginas diferentes, el cual solicitará información al backend para mostrarla (CSR).
+- El proyecto deberá contar con al menos tres (3) entidades diferentes, representadas en tablas de la base de datos, con al menos cinco (5) campos cada una (excluyendo el ID).
+- Debe haber al menos una relación para cada entidad (de entrada o salida), utilizando foreign keys.
+- Se debe contar con un CRUD completo para cada entidad, los cuales deberán ser accesibles desde el frontend.
+- Debe existir la posibilidad de levantar el proyecto utilizando Docker Compose, permitiendo levantar el frontend y el backend por separado.
+- El proyecto deberá contar con un archivo `README.md` con las instrucciones para configurar y levantar el sistema, junto con una descripción del mismo y capturas de pantalla del funcionamiento.
+- El proyecto deberá ser desarrollado utilizando `git`, cumpliendo las prácticas profesadas en clase, y subido a un repositorio privado de GitHub. El desarrollo deberá ser incremental, con commits atómicos y mensajes descriptivos acorde a lo que se realiza en el commit.
+
+En particular, se deben cumplir las siguientes pautas:
+
+- El desarrollo deberá ser incremental, con commits atómicos y mensajes descriptivos.
+- Se deberán utilizar branches para el desarrollo de nuevas funcionalidades, y pull requests para la revisión de código.
+- Los pull requests deberán ser revisados y aprobados por al menos un (1) compañero de grupo.
+
+## Uso de Inteligencia Artificial
+
+Se permite el uso de asistentes de código (como GitHub Copilot, ChatGPT, Gemini, etc.) como herramientas de apoyo para el desarrollo del proyecto. Sin embargo, su uso debe ser **consciente, crítico y declarado**.
+
+- El código generado por IA es responsabilidad absoluta del grupo. Los alumnos deben comprender el 100% del código que entregan.
+- Al momento de la evaluación no se aceptarán excusas como *"la IA lo generó así y no sé cómo funciona"*. Si el código está en el repositorio, el alumno debe poder explicarlo, modificarlo y depurarlo.
+
+## Grupos
+
+Los grupos serán de tres (3) a cuatro (4) alumnos, sin excepción. Los grupos serán formados por los alumnos e informados al docente a través de un formulario de Google Forms, que luego se va a compartir por el canal general de Slack.
+
+## Elección del proyecto
+
+Los grupos deberán planificar un proyecto original y **creativo**, el cual deberá ser aprobado por el docente antes de comenzar el desarrollo. Para ello, se dedicará una clase a la presentación de ideas de proyectos por parte de los grupos, quienes deberán explicar brevemente la temática y los objetivos del mismo. El docente podrá sugerir modificaciones o mejoras a las ideas presentadas.
+
+### Ideas de proyectos permabanneadas
+
+Las siguientes ideas **no están permitidas** como temática del Trabajo Práctico:
+
+- Catálogos de criaturas coleccionables (Pokédex, bestiarios, colección de monstruos, catálogo de personajes con tipos, poderes y evoluciones).
+- Plataformas de adopción de animales.
+- Marketplaces.
+- Alquiler de servicios (cerrajero, electricista, etc.).
+- Aplicaciones para el armado de grupos (para jugar al fútbol, juegos de mesa, tocar música, correr, etc.).
+- Escritura colaborativa/social (Wattpad y similares).
+- Recomendaciones de libros, películas, series.
+- Blogs o redes sociales.
+
+En general, también se desalientan proyectos cuyo núcleo sea únicamente:
+
+- autenticación + publicaciones + comentarios,
+- usuarios + reservas + pagos,
+- usuarios + catálogo + favoritos.
+
+### ¿Qué se espera entonces?
+
+Se valoran más proyectos que:
+
+- tengan reglas de negocio interesantes,
+- modelen procesos reales,
+- manejen estados y validaciones,
+- tengan decisiones de diseño más allá de "guardar cosas en tablas".
+
+## Evaluación
+
+El TP se evaluará en una instancia de final, en la cual los alumnos deberán presentar el proyecto y responder preguntas sobre el mismo. Todos los alumnos del grupo deberán estar presentes en la presentación y haber participado en el desarrollo del proyecto, con commits en el repositorio.
+
+:::tip Punto extra
+
+En caso de contar con el proyecto desplegado en un servicio disponible públicamente en internet, se otorgará un (1) punto extra a la nota final.
 
 :::
+
+Los grupos escogerán una fecha entre las primeras cuatro (4) disponibles para presentar. La quinta y última fecha quedará reservada para los grupos que no hayan aprobado en su primera instancia. En caso de no aprobar en la segunda instancia, los alumnos no habrán regularizado la materia.
+
+## Fechas de Presentación
+
+Las fechas de presentación del trabajo práctico se corresponderán con los primeros cuatro llamados a exámenes finales del período Julio-Agosto de 2026. El quinto llamado (último disponible en el período) estará reservado exclusivamente para la instancia de recuperatorio.
+
+:::danger Importante
+
+Todo grupo que no apruebe en alguno de los llamados disponibles deberá recursar la materia, sin excepciones.
+
+:::
+
+### Fechas de final
+
+Próximamente.
+
+- **Ubicación**: Laboratorios de computación (4° piso de Paseo Colón 850).
+- **Horario**: 19:00 hs.

--- a/src/pages/trabajos-practicos.md
+++ b/src/pages/trabajos-practicos.md
@@ -28,7 +28,7 @@ En particular, se deben cumplir las siguientes pautas:
 Se permite el uso de asistentes de código (como GitHub Copilot, ChatGPT, Gemini, etc.) como herramientas de apoyo para el desarrollo del proyecto. Sin embargo, su uso debe ser **consciente, crítico y declarado**.
 
 - El código generado por IA es responsabilidad absoluta del grupo. Los alumnos deben comprender el 100% del código que entregan.
-- Al momento de la evaluación no se aceptarán excusas como *"la IA lo generó así y no sé cómo funciona"*. Si el código está en el repositorio, el alumno debe poder explicarlo, modificarlo y depurarlo.
+- Al momento de la evaluación no se aceptarán excusas como *"la IA lo generó así y no sé cómo funciona"*. Si el código está en el repositorio, el alumno debe poder explicarlo, modificarlo y debugearlo.
 
 ## Grupos
 

--- a/src/pages/trabajos-practicos.md
+++ b/src/pages/trabajos-practicos.md
@@ -9,7 +9,7 @@ Los alumnos deben demostrar la comprensión de los conceptos aprendidos en clase
 Los alumnos deberán desarrollar un sitio web completo utilizando las tecnologías vistas a lo largo de la materia. El mismo constará de un frontend y un backend, con persistencia de datos utilizando una base de datos. El sitio web deberá tener una temática creativa y original, elegida por cada grupo, y deberá cumplir con los siguientes requisitos:
 
 - El backend deberá ser una API REST.
-- El frontend deberá ser un sitio estático, con al menos tres (3) páginas diferentes, el cual solicitará información al backend para mostrarla (CSR).
+- El frontend deberá ser un sitio estático, con al menos tres (3) páginas diferentes, el cual solicitará información al backend para mostrarla ([CSR](https://developer.mozilla.org/en-US/docs/Glossary/CSR)).
 - El proyecto deberá contar con al menos tres (3) entidades diferentes, representadas en tablas de la base de datos, con al menos cinco (5) campos cada una (excluyendo el ID).
 - Debe haber al menos una relación para cada entidad (de entrada o salida), utilizando foreign keys.
 - Se debe contar con un CRUD completo para cada entidad, los cuales deberán ser accesibles desde el frontend.

--- a/src/pages/trabajos-practicos.md
+++ b/src/pages/trabajos-practicos.md
@@ -84,7 +84,7 @@ Las fechas de presentación del trabajo práctico se corresponderán con los pri
 
 :::danger Importante
 
-Todo grupo que no apruebe en alguno de los llamados disponibles deberá recursar la materia, sin excepciones.
+Todo grupo que no apruebe la instancia de final deberá recursar la materia.
 
 :::
 


### PR DESCRIPTION
Reemplaza el placeholder de la página de Trabajos Prácticos por el enunciado completo del TP, incluyendo objetivo, descripción, requisitos técnicos, pautas de desarrollo, uso de IA, conformación de grupos, lista de ideas permabanneadas, criterios de evaluación y fechas.